### PR TITLE
fix ws switch handler not respecting fullscreen windows

### DIFF
--- a/eww/config/bar.sh
+++ b/eww/config/bar.sh
@@ -10,8 +10,8 @@ function handle
   end
 
   if string match -q "fullscreen>>?" $argv[1]
-
     or string match -q -r "^workspace>>((10)|\d)\$" $argv[1]
+
       set wincount $(hyprctl clients -j | jq -r ". | map(select (.workspace.id == $lastws and .floating == false and .mapped == true)) | length")
       set fswincount $(hyprctl clients -j | jq -r ". | map(select (.workspace.id == $lastws and .fullscreen == true and .mapped == true)) | length")
 

--- a/eww/config/bar.sh
+++ b/eww/config/bar.sh
@@ -7,17 +7,11 @@ function handle
       set ws $(string sub -s 12 $argv[1])
 
       set lastws $ws
-
-      set wincount $(hyprctl clients -j | jq -r ". | map(select (.workspace.id == $ws and .floating == false and .mapped == true)) | length")
-
-      if test $wincount -eq 1
-          echo "nogaps"
-      else
-          echo ""
-      end
   end
+
   if string match -q "fullscreen>>?" $argv[1]
 
+    or string match -q -r "^workspace>>((10)|\d)\$" $argv[1]
       set wincount $(hyprctl clients -j | jq -r ". | map(select (.workspace.id == $lastws and .floating == false and .mapped == true)) | length")
       set fswincount $(hyprctl clients -j | jq -r ". | map(select (.workspace.id == $lastws and .fullscreen == true and .mapped == true)) | length")
 
@@ -29,13 +23,14 @@ function handle
         echo ""
       end
   end
+
   if test -n $lastws
 
     if string match -q "changefloatingmode>>*" $argv[1]
       or string match -q "movewindow>>*" $argv[1]
       or string match -q "openwindow>>*" $argv[1]
       or string match -q "closewindow>>*" $argv[1]
-  
+
         set wincount $(hyprctl clients -j | jq -r ". | map(select (.workspace.id == $lastws and .floating == false and .mapped == true)) | length")
 
         if test $wincount -eq 1


### PR DESCRIPTION
when fullscreening a window, and switching back to the workspace with said fullscreened window, the script wouldn't respect the fullscreened window within the handler for the workspace event.